### PR TITLE
Add Opentelemetry driver

### DIFF
--- a/osprofiler/_utils.py
+++ b/osprofiler/_utils.py
@@ -124,7 +124,7 @@ def itersubclasses(cls, _seen=None):
     _seen = _seen or set()
     try:
         subs = cls.__subclasses__()
-    except TypeError:   # fails only when cls is type
+    except TypeError:  # fails only when cls is type
         subs = cls.__subclasses__(cls)
     for sub in subs:
         if sub not in _seen:
@@ -161,3 +161,20 @@ def shorten_id(span_id):
         # Return a new short id for this
         short_id = shorten_id(uuidutils.generate_uuid())
     return short_id
+
+
+def uuid_to_int128(span_uuid):
+    if isinstance(span_uuid, int):
+        return span_uuid
+    try:
+        span_int = uuid.UUID(span_uuid).int
+    except ValueError:
+        # Return a new short id for this
+        span_int = uuid_to_int128(uuidutils.generate_uuid())
+    return span_int
+
+
+def int128_to_uuid(span_int):
+    s = "{:x}".format(span_int)
+    # uuid.UUID expects a 32 hex digits string even if leading bits are '0'
+    return str(uuid.UUID("0" * (32 - len(s)) + s))

--- a/osprofiler/_utils.py
+++ b/osprofiler/_utils.py
@@ -172,9 +172,3 @@ def uuid_to_int128(span_uuid):
         # Return a new short id for this
         span_int = uuid_to_int128(uuidutils.generate_uuid())
     return span_int
-
-
-def int128_to_uuid(span_int):
-    s = "{:x}".format(span_int)
-    # uuid.UUID expects a 32 hex digits string even if leading bits are '0'
-    return str(uuid.UUID("0" * (32 - len(s)) + s))

--- a/osprofiler/drivers/__init__.py
+++ b/osprofiler/drivers/__init__.py
@@ -4,5 +4,6 @@ from osprofiler.drivers import jaeger  # noqa
 from osprofiler.drivers import loginsight  # noqa
 from osprofiler.drivers import messaging  # noqa
 from osprofiler.drivers import mongodb  # noqa
+from osprofiler.drivers import opentelemetry  # noqa
 from osprofiler.drivers import redis_driver  # noqa
 from osprofiler.drivers import sqlalchemy_driver  # noqa

--- a/osprofiler/drivers/base.py
+++ b/osprofiler/drivers/base.py
@@ -41,6 +41,8 @@ def get_driver(connection_string, *args, **kwargs):
     if backend in ["mysql", "mysql+pymysql", "mysql+mysqldb",
                    "postgresql", "postgresql+psycopg2"]:
         backend = "sqlalchemy"
+    if backend in ["opentelemetry+jaeger"]:
+        backend = "opentelemetry"
     for driver in _utils.itersubclasses(Driver):
         if backend == driver.get_name():
             return driver(connection_string, *args, **kwargs)

--- a/osprofiler/drivers/opentelemetry.py
+++ b/osprofiler/drivers/opentelemetry.py
@@ -86,7 +86,7 @@ class Opentelemetry(Jaeger):
             ctx = self.trace.set_span_in_context(self.trace.NonRecordingSpan(span_context))
             # Create Jaeger Tracing span
             span = self.tracer.start_span(
-                name=payload["name"].rstrip("-start"),
+                name=removesuffix(payload["name"], "-start"),
                 context=ctx,
                 attributes=self.create_span_tags(payload),
                 start_time=int(start_time * 1000000000)
@@ -119,3 +119,9 @@ class Opentelemetry(Jaeger):
                 })
             # Time is in nanosecond (10^9)
             span.end(end_time=int(time.time() * 1000000000))
+
+
+def removesuffix(string, suffix):
+    if string.endswith(suffix):
+        return string[:-len(suffix)]
+    return string

--- a/osprofiler/drivers/opentelemetry.py
+++ b/osprofiler/drivers/opentelemetry.py
@@ -1,0 +1,123 @@
+# Copyright 2018 Fujitsu Ltd.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import collections
+import datetime
+import time
+from urllib import parse as parser
+
+from oslo_config import cfg
+from oslo_serialization import jsonutils
+
+from osprofiler import _utils as utils
+from osprofiler import exc
+import logging
+
+from osprofiler.drivers.jaeger import Jaeger
+
+LOG = logging.getLogger(__name__)
+
+
+class Opentelemetry(Jaeger):
+    def __init__(self, connection_str, project=None, service=None, host=None,
+                 conf=cfg.CONF, **kwargs):
+        """Opentelemetry driver for OSProfiler."""
+
+        super(Opentelemetry, self).__init__(connection_str, project=project,
+                                            service=service, host=host,
+                                            conf=conf, **kwargs)
+        self.tracer = None
+        try:
+            from opentelemetry import trace
+            from opentelemetry.sdk.resources import Resource
+            from opentelemetry.sdk.trace import TracerProvider
+            from opentelemetry.sdk.trace.export import BatchSpanProcessor
+            from opentelemetry.exporter.jaeger.thrift import JaegerExporter
+            resource = Resource.create({"service.name": "{}-{}".format(project, service)})
+            trace.set_tracer_provider(TracerProvider(resource=resource))
+            parsed_url = parser.urlparse(connection_str)
+            jaeger_exporter = JaegerExporter(
+                agent_host_name=parsed_url.hostname,
+                agent_port=parsed_url.port,
+                udp_split_oversized_batches=True
+            )
+            trace.get_tracer_provider().add_span_processor(
+                BatchSpanProcessor(jaeger_exporter),
+            )
+            self.tracer = trace.get_tracer(__name__)
+        except ImportError:
+            raise exc.CommandError(
+                "To use OSProfiler with Uber Jaeger tracer, "
+                "please install `jaeger-client` library. "
+                "To install with pip:\n "
+                "`pip install opentelemetry-api opentelemetry-sdk opentelemetry-exporter-jaeger-thrift`."
+            )
+        self.spans = collections.deque()
+
+    @classmethod
+    def get_name(cls):
+        return "opentelemetry"
+
+    def notify(self, payload):
+        if payload["name"].endswith("start"):
+            timestamp = datetime.datetime.strptime(payload["timestamp"],
+                                                   "%Y-%m-%dT%H:%M:%S.%f")
+            epoch = datetime.datetime.utcfromtimestamp(0)
+            start_time = (timestamp - epoch).total_seconds()
+            from opentelemetry import trace
+            from opentelemetry.trace.propagation import set_span_in_context
+
+            span_context = trace.SpanContext(
+                trace_id=utils.uuid_to_int128(payload["base_id"]),
+                span_id=utils.shorten_id(payload["parent_id"]),
+                is_remote=False,
+                trace_flags=trace.TraceFlags(trace.TraceFlags.SAMPLED)
+            )
+            ctx = trace.set_span_in_context(trace.NonRecordingSpan(span_context))
+            # Create Jaeger Tracing span
+            span = self.tracer.start_span(
+                name=payload["name"].rstrip("-start"),
+                context=ctx,
+                attributes=self.create_span_tags(payload),
+                start_time=int(start_time * 1000000000)
+            )
+            # Replace Jaeger Tracing span_id (random id) to OSProfiler span_id
+            # SpanContext is immutable and there is no easy method to set span_id at span creation
+            c = trace.SpanContext(
+                trace_id=span.context.trace_id,
+                span_id=utils.shorten_id(payload["trace_id"]),
+                is_remote=span.context.is_remote,
+                trace_flags=span.context.trace_flags,
+                trace_state=span.context.trace_state
+            )
+            span._context = c
+            self.spans.append(span)
+        else:
+            span = self.spans.pop()
+
+            # Store result of db call and function call
+            for call in ("db", "function"):
+                if payload.get("info", {}).get(call) is not None:
+                    span.set_attribute("result", payload["info"][call]["result"])
+
+            # Span error tag and log
+            if payload["info"].get("etype") is not None:
+                span.set_attribute("error", True)
+                span.add_event("log", {
+                    "error.kind": payload["info"]["etype"],
+                    "message": payload["info"]["message"]
+                })
+            # Time is in nanosecond (10^9)
+            span.end(end_time=int(time.time() * 1000000000))

--- a/osprofiler/drivers/utils.py
+++ b/osprofiler/drivers/utils.py
@@ -1,0 +1,38 @@
+import re
+
+uuidhex = re.compile('[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}')
+uuid_without_dash = re.compile('[0-9a-fA-F]{32}')
+numerical_id = re.compile('^[0-9]+$')
+subst = {
+    "bindings": "{hostname}",
+    "os-keypairs": "{keypair_name}",
+    "block-device-mapping": "{block_device}"
+}
+
+
+def clean_url(url):
+    t = url.split('?')
+    # Remove query string part
+    target_url = t[0]
+    # Split url per 'directory'
+    t1 = target_url.split('/')
+    for i in range(len(t1)):
+        # In Openstack services, first part of url is never variable
+        # - first token is '' as the URL begins with '/'
+        # - second token is the real first part of url and is not variable in openstack
+        if i < 2:
+            continue
+        collection_name = t1[i - 1]
+        # We try to extract the singular of the collection
+        if collection_name[-1] == 's':
+            collection_name = collection_name[:-1]
+        if uuidhex.match(t1[i]) or uuid_without_dash.match(t1[i]):
+            t1[i] = "{" + collection_name + "_uuid}"
+        if numerical_id.match(t1[i]):
+            t1[i] = "{" + collection_name + "_id}"
+        # Some exceptions when argument is not an uuid nor a numerical id
+        t1[i] = subst.get(t1[i - 1], t1[i])
+
+    target_url = "/".join(t1)
+
+    return target_url

--- a/osprofiler/tests/unit/drivers/test_opentelemetry.py
+++ b/osprofiler/tests/unit/drivers/test_opentelemetry.py
@@ -1,0 +1,78 @@
+# Copyright 2018 Fujitsu Ltd.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from unittest import mock
+
+from osprofiler.drivers import opentelemetry
+from osprofiler.tests import test
+
+
+class OpentelemetryTestCase(test.TestCase):
+
+    def setUp(self):
+        super(OpentelemetryTestCase, self).setUp()
+        self.payload_start = {
+            "name": "api-start",
+            "base_id": "4e3e0ec6-2938-40b1-8504-09eb1d4b0dee",
+            "trace_id": "1c089ea8-28fe-4f3d-8c00-f6daa2bc32f1",
+            "parent_id": "e2715537-3d1c-4f0c-b3af-87355dc5fc5b",
+            "timestamp": "2018-05-03T04:31:51.781381",
+            "info": {
+                "host": "test"
+            }
+        }
+
+        self.payload_stop = {
+            "name": "api-stop",
+            "base_id": "4e3e0ec6-2938-40b1-8504-09eb1d4b0dee",
+            "trace_id": "1c089ea8-28fe-4f3d-8c00-f6daa2bc32f1",
+            "parent_id": "e2715537-3d1c-4f0c-b3af-87355dc5fc5b",
+            "timestamp": "2018-05-03T04:31:51.781381",
+            "info": {
+                "host": "test",
+                "function": {
+                    "result": 1
+                }
+            }
+        }
+
+        self.driver = opentelemetry.Opentelemetry("jaeger://127.0.0.1:6831",
+                                                  project="nova", service="api")
+
+    @mock.patch("osprofiler._utils.shorten_id")
+    def test_notify_start(self, mock_shorten_id):
+        self.driver.notify(self.payload_start)
+        calls = [
+            mock.call(self.payload_start["base_id"]),
+            mock.call(self.payload_start["parent_id"]),
+            mock.call(self.payload_start["trace_id"])
+        ]
+        mock_shorten_id.assert_has_calls(calls, any_order=True)
+
+    @mock.patch("jaeger_client.span.Span")
+    @mock.patch("time.time")
+    def test_notify_stop(self, mock_time, mock_span):
+        fake_time = 1525416065.5958152
+        mock_time.return_value = fake_time
+
+        span = mock_span()
+        self.driver.spans.append(mock_span())
+
+        self.driver.notify(self.payload_stop)
+
+        mock_time.assert_called_once()
+        mock_time.reset_mock()
+
+        span.finish.assert_called_once_with(finish_time=fake_time)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -20,5 +20,9 @@ redis>=2.10.0 # MIT
 
 # For Jaeger Tracing
 jaeger-client>=3.8.0 # Apache-2.0
+# For Opentelemetry tracing
+opentelemetry-api>=1.12.0
+opentelemetry-exporter-jaeger-thrift>=1.12.0
+opentelemetry-sdk>=1.12.0
 
 pre-commit>=2.6.0 # MIT


### PR DESCRIPTION
Fixes #2 

Create a new driver for jaeger target that will use opentelemetry libraries : 
* jaeger-client library is DEPRECATED
* in some cases, issues has been found between tornado (used by jaeger-client) and eventlet : 
  * https://github.com/jaegertracing/jaeger-client-python/issues/191
  * https://github.com/jaegertracing/jaeger-client-python/issues/235
  * https://github.com/jaegertracing/jaeger-client-python/issues/265